### PR TITLE
Liquidity check bug

### DIFF
--- a/src/entities/transfer.ts
+++ b/src/entities/transfer.ts
@@ -33,13 +33,14 @@ export class Transfer<TInput extends Currency> {
 
   public verifyTransfer = () => {
     const fromToken = this.direction.supportedSourceToken
+    const toToken = this.direction.supportedDestinationToken
 
     invariant(
       this.amount.greaterThanOrEqual(fromToken.minDeposit) && this.amount.lessThanOrEqual(fromToken.maxDeposit),
       'AMOUNT_THRESHOLD'
     )
 
-    invariant(this.amount.lessThanOrEqual(fromToken.availableLiquidity), 'LIQUIDITY')
+    invariant(this.amount.lessThanOrEqual(toToken.availableLiquidity), 'LIQUIDITY')
 
     invariant(
       JSBI.greaterThanOrEqual(

--- a/src/tests/transfer.test.ts
+++ b/src/tests/transfer.test.ts
@@ -19,7 +19,7 @@ describe('transfer', () => {
     DAI,
     CurrencyAmount.fromRawAmount(DAI, '20'),
     CurrencyAmount.fromRawAmount(DAI, '50'),
-    CurrencyAmount.fromRawAmount(DAI, '35')
+    CurrencyAmount.fromRawAmount(DAI, '100')
   )
   const supportedTokensFrom = {
     '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': stUSDC,
@@ -39,7 +39,7 @@ describe('transfer', () => {
     DAI2,
     CurrencyAmount.fromRawAmount(DAI, '20'),
     CurrencyAmount.fromRawAmount(DAI, '30'),
-    CurrencyAmount.fromRawAmount(DAI, '100')
+    CurrencyAmount.fromRawAmount(DAI, '35')
   )
   const supportedTokensTo = { '0x6B175474E89094C44Da98b954EedeAC495271d0F': stDAI2 }
   const vaultTo = new Vault(


### PR DESCRIPTION
The verifyTransfer function in the Transfer entity verifies the token available liquidity in the origin vault, but it should check the destination vault liquidity instead